### PR TITLE
Handle persistent message decoding error

### DIFF
--- a/cryptowatch/stream/__init__.py
+++ b/cryptowatch/stream/__init__.py
@@ -38,6 +38,8 @@ def _on_close(ws):
 
 def on_market_update(ws, message):
     try:
+        if message == b'\x01':
+            return
         stream_message = stream_pb2.StreamMessage()
         stream_message.ParseFromString(message)
         if str(stream_message.marketUpdate.intervalsUpdate):


### PR DESCRIPTION
Hi,

This is my first time contributing code to a public repo so be gentle!

Using the websocket generates a ton of decoding errors on the console:

```
2021-02-10 22:14:55,118 - cryptowatch - ERROR - Could not decode this message: b'\x01'
ERROR:cryptowatch:Could not decode this message: b'\x01'
2021-02-10 22:14:55,119 - cryptowatch - ERROR - Traceback (most recent call last):
  File "/Users/rozling/PycharmProjects/cw/venv/lib/python3.9/site-packages/cryptowatch/stream/__init__.py", line 42, in on_market_update
    stream_message.ParseFromString(message)
  File "/Users/rozling/PycharmProjects/cw/venv/lib/python3.9/site-packages/google/protobuf/message.py", line 199, in ParseFromString
    return self.MergeFromString(serialized)
  File "/Users/rozling/PycharmProjects/cw/venv/lib/python3.9/site-packages/google/protobuf/internal/python_message.py", line 1145, in MergeFromString
    if self._InternalParse(serialized, 0, length) != length:
  File "/Users/rozling/PycharmProjects/cw/venv/lib/python3.9/site-packages/google/protobuf/internal/python_message.py", line 1195, in InternalParse
    raise message_mod.DecodeError('Field number 0 is illegal.')
google.protobuf.message.DecodeError: Field number 0 is illegal.
```

This seems to be due to some kind of binary data being sent on the websocket (maybe a heartbeat/keepalive thing?).  Since it's happening every few seconds it pollutes the console with these stacktraces, so I figured why not just handle it this way, as it's a common case?

Might be a bit simplistic / naive an approach - if so I'm happy to be schooled in the right way to do it :)

Tested with `make test-http-real`, all tests passed (warnings are unrelated deprecation warnings):
![Screenshot 2021-02-10 at 22 26 07](https://user-images.githubusercontent.com/1826422/107568627-f4011700-6bef-11eb-8891-f65b3c356750.png)
